### PR TITLE
Short vs. Octet mismatch

### DIFF
--- a/converter/lib/create_xmls.py
+++ b/converter/lib/create_xmls.py
@@ -85,10 +85,12 @@ def formatSCD(rp, ports):
             raise Exception("Unknown block port direction: %s" % port.type)
     
     for dt in all_data_types:
-        all_interfaces.add_interface(scd.interface(dt[0], "IDL:BULKIO/{0}:1.0".format(dt[0]), [
-            scd.inheritsInterface("IDL:BULKIO/{0}PortStatisticsProvider:1.0".format(dt[1]), 
-            scd.inheritsInterface("IDL:BULKIO/updateSRI:1.0")
-        ]))
+        if dt[1] == "Provides":
+            all_interfaces.add_interface(scd.interface(dt[0], "IDL:BULKIO/{0}:1.0".format(dt[0]), [
+                scd.inheritsInterface("IDL:BULKIO/{0}PortStatisticsProvider:1.0".format(dt[1]), 
+                scd.inheritsInterface("IDL:BULKIO/updateSRI:1.0")]))
+        else:
+            all_interfaces.add_interface(scd.interface(dt[0], "IDL:BULKIO/{0}:1.0".format(dt[0])))
 
     rp.scd.set_interfaces(all_interfaces)
     rp.scd.componentfeatures.set_ports(ports_scd)

--- a/converter/lib/create_xmls.py
+++ b/converter/lib/create_xmls.py
@@ -87,11 +87,11 @@ def formatSCD(rp, ports):
     for dt in all_data_types:
         if dt[1] == "Provides":
             all_interfaces.add_interface(scd.interface(dt[0], "IDL:BULKIO/{0}:1.0".format(dt[0]), [
-                scd.inheritsInterface("IDL:BULKIO/{0}PortStatisticsProvider:1.0".format(dt[1]), 
+                scd.inheritsInterface("IDL:BULKIO/{0}PortStatisticsProvider:1.0".format(dt[1])), 
                 scd.inheritsInterface("IDL:BULKIO/updateSRI:1.0")]))
         else:
             all_interfaces.add_interface(scd.interface(dt[0], "IDL:BULKIO/{0}:1.0".format(dt[0])))
-
+    
     rp.scd.set_interfaces(all_interfaces)
     rp.scd.componentfeatures.set_ports(ports_scd)
 


### PR DESCRIPTION
The integration package (correctly) uses `dataOctet` when mapping to GR `byte` ports, but the converter was written to use `dataShort` (incorrect, as it causes issues with Java implementations hence why it is not visible by default in the IDE).  

Additionally, the converter was adding a single `interface` hard-coded to `dataShort` `Provides` with port statistics when it should have an interface specific to the types of ports, and only provide the statistics interface for Provides ports.

This patch should sync up the converter to the integration package for handling "byte" data types.